### PR TITLE
업데이트 로직 개선

### DIFF
--- a/download.php
+++ b/download.php
@@ -5,17 +5,17 @@ title: 경기과학고 텍 사용자협회
 description: "LaTeX is a high-quality typesetting system; it includes features designed for the production of technical and scientific documentation."
 ---
 <?php
-	$size_1=number_format(filesize("files/gshslatexintro.zip")/1024/1024,2);
+	$size_1=number_format(filesize("files/gshs-format.zip")/1024/1024,2);
 	$size_2=number_format(filesize("files/examples.zip")/1024/1024,2);
 	$size_3=number_format(filesize("files/An-Introduction-to-LaTeX.zip")/1024/1024,2);
 	$size_4=number_format(filesize("files/examples-mirror.zip")/1024/1024,2);
-	$size_5=number_format(filesize("files/gshslatexintro-mirror.zip")/1024/1024,2);
+	$size_5=number_format(filesize("files/gshs-format-mirror.zip")/1024/1024,2);
 ?>
 <h1>다운로드</h1>
 
 <div class="row">
 	<div class="col cell1of3">
-		<a href="files/gshslatexintro.zip" class="btn"><b>양식</b>(<?php echo $size_1 ?>MB)</a>
+		<a href="files/gshs-format.zip" class="btn"><b>양식</b>(<?php echo $size_1 ?>MB)</a>
 		<br>
 		R&E, 졸업논문, 휴텍 양식 등
 	</div>
@@ -33,7 +33,7 @@ description: "LaTeX is a high-quality typesetting system; it includes features d
 <hr>
 <div class="row">
 	<div class="col cell1of3">
-		<a href="files/gshslatexintro-mirror.zip" class="btn"><b>양식-mirror</b>(<?php echo $size_5 ?>MB)</a>
+		<a href="files/gshs-format-mirror.zip" class="btn"><b>양식-mirror</b>(<?php echo $size_5 ?>MB)</a>
 		<br>
 		컴파일된 pdf파일 포함 버전
 	</div>

--- a/update_files.sh
+++ b/update_files.sh
@@ -1,5 +1,10 @@
-# Repo information
+#!/usr/bin/env bash
+# Git repo information
+org_url=https://github.com/gshslatexintro
 repo_list="An-Introduction-to-LaTeX examples examples-mirror gshs-format gshs-format-mirror"
+
+find_branch="git symbolic-ref -q HEAD"
+find_upstream="git for-each-ref --format=%(upstream:short)"
 
 echo Started updating files...
 date
@@ -9,10 +14,19 @@ cd /var/www/source/files/
 for repo in $repo_list; do
 echo Repo $repo...
 if [ ! -d $repo ]; then
-git clone https://github.com/gshslatexintro/$repo
+git clone $org_url/$repo
 fi
 pushd $repo
-git pull
-zip -FSr ../$repo.zip /*
+git fetch --all
+echo Checkout $($find_upstream $($find_branch))...
+git reset --hard $($find_upstream $($find_branch))
+zip -FSr ../$repo.zip *
 popd
 done
+
+echo Time...
+date > /var/www/source/updated.txt
+
+echo Building website...
+cd /var/www/source
+jekyll build

--- a/update_files.sh
+++ b/update_files.sh
@@ -1,34 +1,18 @@
+# Repo information
+repo_list="An-Introduction-to-LaTeX examples examples-mirror gshs-format gshs-format-mirror"
+
 echo Started updating files...
 date
 
-echo Repo 1...
-cd /var/www/source/files/An-Introduction-to-LaTeX
+cd /var/www/source/files/
+
+for repo in $repo_list; do
+echo Repo $repo...
+if [ ! -d $repo ]; then
+git clone https://github.com/gshslatexintro/$repo
+fi
+pushd $repo
 git pull
-zip -FSr /var/www/source/files/An-Introduction-to-LaTeX.zip *
-
-echo Repo 2...
-cd /var/www/source/files/examples
-git pull
-zip -FSr /var/www/source/files/examples.zip *
-
-echo Repo 3...
-cd /var/www/source/files/gshslatexintro
-git pull
-zip -FSr /var/www/source/files/gshslatexintro.zip *
-
-echo Repo 4...
-cd /var/www/source/files/examples-mirror
-git pull
-zip -FSr /var/www/source/files/examples-mirror.zip *
-
-echo Repo 5...
-cd /var/www/source/files/gshslatexintro-mirror
-git pull
-zip -FSr /var/www/source/files/gshslatexintro-mirror.zip *
-
-echo Time...
-date > /var/www/source/updated.txt
-
-echo Building website...
-cd /var/www/source
-jekyll build
+zip -FSr ../$repo.zip /*
+popd
+done

--- a/update_posts.sh
+++ b/update_posts.sh
@@ -1,7 +1,13 @@
+#!/usr/bin/env bash
+
+find_branch="git symbolic-ref -q HEAD"
+find_upstream="git for-each-ref --format=%(upstream:short)"
+
 echo Started updating posts...
 date
 
 echo Updating posts and website...
 cd /var/www/source
-git pull
+git fetch --all
+git reset --hard $($find_upstream $($find_branch))
 jekyll build


### PR DESCRIPTION
변경 사항:
- repository 이름을 추가하기만 하면 서버 측에서 별도로 clone하지 않아도 자동으로 clone한 뒤 archive를 만들어 줍니다.
- `git pull` 대신 `git reset --hard`를 사용하여 force push 등의 상황에 유연하게 대처합니다.
- repository 이름에 맞게 파일 링크를 수정합니다.

참고: 변경된 스크립트에서는 서버 쪽에서 수정한 사항을 자동으로 폐기합니다. 서버 쪽에서 무언가 수정한 경우([예시](https://github.com/gshslatexintro/latex.gs.hs.kr/commits?author=invalid-email-address)) 업데이트 주기에 도달하기 전에 커밋하고 push해야만 하는 문제가 있습니다.
이 경우 새로운 branch를 만들어서 커밋하면 upstream branch가 설정되지 않았으므로 업데이트가 되지 않습니다. 다시 원래의 branch(일반적으로 `master`)를 checkout하면 정상적으로 업데이트가 진행됩니다.